### PR TITLE
Fix : 큐레이션 추가 페이지 렌더링 시 최상단으로 이동 수정

### DIFF
--- a/src/components/Profile/UserPlace/UserPlace.jsx
+++ b/src/components/Profile/UserPlace/UserPlace.jsx
@@ -29,7 +29,6 @@ export default function UserPlace() {
                     }
                 })
                 const resJson = await res.json()
-                console.log(resJson);
                 setCurationData(resJson)
             } catch (e) {
                 console.log(e);
@@ -47,8 +46,6 @@ export default function UserPlace() {
         });
         setIsCategory(newState);
     };
-
-    console.log(curationData);
 
     return (
         <div>

--- a/src/components/SlideList/DetailPlaceList/DetailPlaceList.jsx
+++ b/src/components/SlideList/DetailPlaceList/DetailPlaceList.jsx
@@ -4,7 +4,6 @@ import * as S from "./style";
 
 export default function DetailPlaceList({data, placeList}) {
     window.scrollTo(0, 0)
-    console.log(placeList);
 
     return (
         <S.ListDetailPlace>

--- a/src/pages/PlaceDetail/PlaceDetail.jsx
+++ b/src/pages/PlaceDetail/PlaceDetail.jsx
@@ -198,7 +198,7 @@ export default function PlaceDetail() {
                             {
                                 !!detailData
                                 ? detailData.overview
-                                : place.desc
+                                : <></>
                             }
                         </S.ParagraphDescription>
                     </S.SectionHome>

--- a/src/pages/Profile/ProfileAddQuration/ProfileAddQuration.jsx
+++ b/src/pages/Profile/ProfileAddQuration/ProfileAddQuration.jsx
@@ -9,7 +9,7 @@ export default function ProfileAddQuration() {
     let token = localStorage.getItem('Access Token');
 
     const location = useLocation();
-    const checklist = location.state.checklist
+    const checklist = location.state.checklist.current
     const id = location.state.id
 
     const [title, setTitle] = useState(() =>

--- a/src/pages/Profile/ProfileAddQuration/QurationPlaceList/QurationListItem.jsx
+++ b/src/pages/Profile/ProfileAddQuration/QurationPlaceList/QurationListItem.jsx
@@ -3,17 +3,13 @@ import CheckFillImage from '../../../../assets/images/icon-check-fill.svg'
 import CheckImage from '../../../../assets/images/icon-check.svg'
 import * as S from "../../style"
 
-export default function QurationListItem({ checklist, getChecklist, deleteChecklist, place }) {
+function QurationListItem({ checklist, getChecklist, deleteChecklist, place }) {
     const [isCheck, setIsCheck] = useState(false)
 
-    const setChecklistValue = (e) => {
-        getChecklist(e)
-    }
-
-    function handleClick() {
+     const handleClick = ()=> {
         setIsCheck(!isCheck)
-        if (!isCheck) setChecklistValue(place)
-        if(checklist.length > 0 && isCheck) {
+        if (!isCheck) getChecklist(place)
+        if (checklist.current.length > 0 && isCheck) {
             deleteChecklist(place)
         }     
     }
@@ -30,8 +26,10 @@ export default function QurationListItem({ checklist, getChecklist, deleteCheckl
                     </S.ParagraphDesc>
                 </div>
                 <S.ButtonCheck>
-                <S.ImageCheck src={isCheck ? CheckFillImage : CheckImage} onClick={handleClick} alt='선택' />
+                <S.ImageCheck src={ isCheck ? CheckFillImage : CheckImage} onClick={handleClick} alt='선택' />
                 </S.ButtonCheck>
             </S.ListItemResult>
     )
 }
+
+export default QurationListItem;

--- a/src/pages/Profile/ProfileAddQuration/QurationPlaceList/QurationPlaceList.jsx
+++ b/src/pages/Profile/ProfileAddQuration/QurationPlaceList/QurationPlaceList.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Link, useLocation } from 'react-router-dom';
 import SearchIcon from '../../../../assets/images/icon-search.svg';
@@ -8,22 +8,29 @@ import QurationListItem from './QurationListItem';
 export default function QurationPlaceList() {
     const { placeData } = useSelector(state => state.placeData);
     const [input, setInput] = useState('')
-    const [checklist, setChecklist] = useState('');
     const data = Object.entries(placeData.area);
     const location = useLocation();
     const id = location.state.id
     const list = location.state.checklist
 
+    const checklist = useRef([])
+
+    const [isActive, setIsActive] = useState(false)
+
     const getChecklist = (e) => {
-        let newArr = [...checklist, e]
-        setChecklist(newArr)
+        let newArr = [...checklist.current, e]
+        checklist.current = newArr;
     }
 
     const deleteChecklist = (e) => {
-        let newArr = checklist.filter(i => i !== e)
-        setChecklist(newArr)
+        let newArr = checklist.current.filter(i => i !== e)
+        checklist.current = newArr
     }
 
+    useEffect(() => {
+        checklist.current ?  setIsActive(true) : setIsActive(false)
+    }, [checklist])
+    
     const handleInput = (e) => {
         setInput(e.target.value)
     }
@@ -64,12 +71,14 @@ export default function QurationPlaceList() {
                     <>
                         <S.ListResult>
                             {
-                                searchlist.map(item => {
-                                    return (
-                                        <QurationListItem checklist={checklist} getChecklist={getChecklist} key={item.contentid} deleteChecklist={deleteChecklist} place={item} />    
-                                    )
-                                })
-                            }
+                                searchlist
+                                    .map(place => {
+                                        return (
+                                            <QurationListItem checklist={checklist} getChecklist={getChecklist} key={place.contentid} deleteChecklist={deleteChecklist} place={place} />    
+                                        )
+                                    })
+
+                                }
                         </S.ListResult>
                     </> 
                     :
@@ -90,7 +99,7 @@ export default function QurationPlaceList() {
                     </>
             }
             <Link to='/profile/addquration' state={{ checklist, id}} >
-                <S.ButtonSave className={checklist.length > 0 ? "on" : false}>저장</S.ButtonSave>
+                <S.ButtonSave className={isActive ? "on" : false}>저장</S.ButtonSave>
             </Link>
         </S.SectionList>
     )


### PR DESCRIPTION
### PR 목적
- [X] 버그 수정 : 큐레이션 추가 페이지 렌더링 시 최상단으로 이동 수정


### 요약
- 큐레이션 추가 페이지에서 장소 선택 시, 렌더링으로 인해 최상단으로 이동
- checklist 관리 시, useRef 사용하여 수정

### Issue Number
close : #